### PR TITLE
Vulnerabilities fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,20 +12,19 @@
     <compiler.plugin.version>3.8.1</compiler.plugin.version>
     <assembly.plugin.version>3.1.1</assembly.plugin.version>
 
+    <jetty.version>9.4.53.v20231009</jetty.version>
 
-    <jetty.version>9.4.50.v20221201</jetty.version>
-    
     <jodconverter.version>2.2.1</jodconverter.version>
     <startup.parameters.version>1.0-5</startup.parameters.version>
 
     <slf4j.version>1.7.28</slf4j.version>
-    <logback.version>1.2.9</logback.version>
+    <logback.version>1.2.13</logback.version>
 
     <junit.version>4.13.1</junit.version>
 
     <jacoco.version>0.8.0</jacoco.version>
 
-    <batik.version>1.16</batik.version>
+    <batik.version>1.17</batik.version>
 
     <sonar.jacoco.reportPaths>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPaths>
     <sonar.language>java</sonar.language>
@@ -85,22 +84,20 @@
         <groupId>com.artofsolving</groupId>
         <artifactId>jodconverter</artifactId>
         <version>${jodconverter.version}</version>
-        <!-- Fix of CVE-2021-29425 (part 1 of 2)
+        <!-- Fix of CVE-2021-29425 (part 1 of 2) -->
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
-        -->
       </dependency>
-      <!-- Fix of CVE-2021-29425 (part 2 of 2)
+      <!-- Fix of CVE-2021-29425 (part 2 of 2) -->
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.7</version>
       </dependency>
-      -->
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
The following security vulnerabilities were fixed:
    CVE-2021-29425
    CVE-2022-44729
    CVE-2022-44730
    CVE-2023-36478
    CVE-2023-36479
    CVE-2023-44487
    CVE-2023-26048
    CVE-2023-26049
    CVE-2023-40167
    CVE-2023-41900
    CVE-2023-6378

Vulnerabilities were related to the following libraries:
    batik-css-1.16.jar
    batik-i18n-1.16.jar
    commons-io-1.3.1.jar
    jetty-io-9.4.50.v20221201.jar
    jetty-server-9.4.50.v20221201.jar
    logback-core-1.2.9.jar